### PR TITLE
🐛 Fix: Handle case-insensitive FROM and ORDER BY without touching record ID casing

### DIFF
--- a/core/classes/AsyncProcessor.cls
+++ b/core/classes/AsyncProcessor.cls
@@ -116,7 +116,6 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
     return process;
   }
 
-  @TestVisible
   private Integer getRecordCount(String query) {
     String lowerQuery = query.toLowerCase();
     Integer fromIndex = lowerQuery.lastIndexOf(' from ');

--- a/core/classes/AsyncProcessor.cls
+++ b/core/classes/AsyncProcessor.cls
@@ -21,7 +21,7 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
    * Process interface-related methods
    */
   public Process get(String query) {
-    return this.getProcess(query?.toLowerCase(), null);
+    return this.getProcess(query, null);
   }
 
   public Process get(List<SObject> records) {
@@ -116,18 +116,17 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
     return process;
   }
 
+  @TestVisible
   private Integer getRecordCount(String query) {
-    String countQuery = query.replace(
-      query.substringBeforeLast(' from '),
-      'select count() '
-    );
-    Integer possibleOrderStatement = query.lastIndexOfIgnoreCase('order by');
-    if (possibleOrderStatement > -1) {
-      countQuery = countQuery.replace(
-        query.substring(possibleOrderStatement),
-        ''
-      );
-    }
+    String lowerQuery = query.toLowerCase();
+    Integer fromIndex = lowerQuery.lastIndexOf(' from ');
+    Integer orderByIndex = lowerQuery.lastIndexOf('order by');
+
+    String fromClause = (orderByIndex > -1)
+        ? query.substring(fromIndex, orderByIndex)
+        : query.substring(fromIndex);
+
+    String countQuery = 'SELECT count()' + fromClause;
     return Database.countquery(countQuery);
   }
 

--- a/core/classes/AsyncProcessorTests.cls
+++ b/core/classes/AsyncProcessorTests.cls
@@ -172,4 +172,14 @@ private class AsyncProcessorTests extends AsyncProcessor {
 
     Assert.isNull(ex);
   }
+
+  @IsTest
+  static void caseInsensitiveFromAndOrderBy() {
+    Organization orgRecord = [SELECT Id FROM Organization LIMIT 1];
+
+    String mixedCaseQuery = 'sEleCT id FrOM Organization Where Id = \'' + orgRecord.Id + '\' OrDeR bY Name';
+    Integer count = new AsyncProcessorTests().getRecordCount(mixedCaseQuery);
+
+    Assert.areEqual(1, count, 'Expected to count 1 Organization record with mixed-case query.');
+  }
 }

--- a/core/classes/AsyncProcessorTests.cls
+++ b/core/classes/AsyncProcessorTests.cls
@@ -175,11 +175,18 @@ private class AsyncProcessorTests extends AsyncProcessor {
 
   @IsTest
   static void caseInsensitiveFromAndOrderBy() {
+    Exception ex;
     Organization orgRecord = [SELECT Id FROM Organization LIMIT 1];
-
     String mixedCaseQuery = 'sEleCT id FrOM Organization Where Id = \'' + orgRecord.Id + '\' OrDeR bY Name';
-    Integer count = new AsyncProcessorTests().getRecordCount(mixedCaseQuery);
+    
+    try {
+      Test.startTest();
+      new AsyncProcessorTests().get(mixedCaseQuery).kickoff();
+      Test.stopTest();
+    } catch (Exception e) {
+      ex = e;
+    }
 
-    Assert.areEqual(1, count, 'Expected to count 1 Organization record with mixed-case query.');
+    Assert.isNull(ex, 'Expected no exception when using mixed-case SOQL.');
   }
 }


### PR DESCRIPTION
Hi @jamessimone, ☺️ 
This PR fixes an issue in the getRecordCount(String query) method where mixed-case SOQL (e.g. FrOM, OrDeR BY) caused unexpected behavior.

The root cause in my case was that a Salesforce record ID is case-sensitive, and when lowercasing the whole query to detect the FROM clause, the ID was unintentionally modified, resulting in no records being found.
Which caused Database.countQuery() to return 0 results with a apex list exception.

**Whats been changed**
- FROM and ORDER BY are now matched using .toLowerCase() purely for position checks, but all slicing is done on the original string to avoid altering casing.
- We also removed the use of .toLowerCase() in get(String query) → getProcess(...), so IDs or field values passed into the query remain untouched.
- A test that uses the Orga object with a mixed-case query and a known ID to make sure the case and position checks works as expected.

_Examples of mixed query with result_
<img width="759" height="412" alt="incentiveQuery_success" src="https://github.com/user-attachments/assets/aede635b-08bf-4467-a473-17eaeb4419b6" />

_Example of lowercase query with no result_
<img width="953" height="485" alt="lowercaseQuery_NoResult" src="https://github.com/user-attachments/assets/200e50f6-bfbc-4b00-b5f9-c90e4594bfe1" />
