### PR TITLE
✨ Expose Async Job ID for logging and debugging

### DIFF
--- a/core/classes/AsyncProcessor.cls
+++ b/core/classes/AsyncProcessor.cls
@@ -3,6 +3,7 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
   private Boolean hasBeenEnqueuedAsync = false;
   private String query;
   private AsyncProcessorQueueable queueable;
+  private Id asyncJobId;
 
   protected List<SObject> records;
   private final List<SObject> chunkRecords = new List<SObject>();
@@ -173,6 +174,7 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
     }
 
     public void execute(System.QueueableContext qc) {
+      this.processor.setAsyncJobId(qc.getJobId());
       // once we've enqueued, it's fine to reset this flag
       this.processor.hasBeenEnqueuedAsync = false;
 
@@ -270,6 +272,14 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
         ? target.substring(0, maxLength)
         : target;
     }
+  }
+
+  public void setAsyncJobId(Id jobId) {
+    this.asyncJobId = jobId;
+  }
+
+  public Id getAsyncJobId() {
+      return this.asyncJobId;
   }
 
   private class QueueableToBatchableContext implements Database.BatchableContext {

--- a/core/classes/AsyncProcessor.cls
+++ b/core/classes/AsyncProcessor.cls
@@ -274,11 +274,11 @@ public abstract without sharing class AsyncProcessor implements Database.AllowsC
     }
   }
 
-  public void setAsyncJobId(Id jobId) {
+  private void setAsyncJobId(Id jobId) {
     this.asyncJobId = jobId;
   }
 
-  public Id getAsyncJobId() {
+  protected Id getAsyncJobId() {
       return this.asyncJobId;
   }
 


### PR DESCRIPTION
These methods allow any class extensions of AsyncProcessor to access the AsyncApexJob ID when the process is running in a queueable context.

**Why**
I ran into a situation where a queueable job failed and I wanted to log which async job caused the error, but this information wasn’t easily available in my extending class.